### PR TITLE
Fix doc for read_data seed type

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ simulation.run_simulation(&models); // or run_simulation_quiet(&models)
 1. Read the data using the method:
 
 ```rust
-pub fn read_data(&self, model: JohansenModel) -> std::io::Result<Vec<(u64, Vec<f64>)>>
+pub fn read_data(&self, model: JohansenModel) -> std::io::Result<Vec<(u32, Vec<f64>)>>
 ```
 
 ### Complete example


### PR DESCRIPTION
## Summary
- correct `read_data` return type in README

## Testing
- `cargo fmt`
- `cargo clippy -- -D warnings` *(fails: failed to get `nalgebra` as a dependency)*
- `cargo check` *(fails: failed to get `nalgebra` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6866bd8bf9808327ac05e266557e3981